### PR TITLE
docs(wavemux): expand README protocol map

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,35 +1,73 @@
 # wavemux
 
-Multiplexed audio-stream protocol for SDR applications. Packs audio
-from many substreams (talkgroups, channels) into a single connection,
-with silent substreams emitting nothing.
+`wavemux` is the shared multiplexed audio stream protocol crate for the SDR
+stack. It lets a producer carry many radio substreams, such as conventional
+channels or trunked talkgroups, over one connection while omitting silent
+substreams entirely.
 
-## Two wire encodings
+The main producer is
+[`WaveCatch`](https://github.com/TobiasWooldridge/WaveCatch), and the main
+consumer today is [`WaveCap`](https://github.com/TobiasWooldridge/WaveCap).
+Keep this crate small and protocol-focused so both sides can update the wire
+boundary without depending on each other's full workspaces.
 
-- **Binary** (`src/wire.rs`) — 12-byte subframe header + payload,
-  multiple subframes per frame. The format is documented in the
-  module docstring at the top of `src/lib.rs`.
-- **JSONL** (`src/jsonl.rs`) — NDJSON for HTTP consumers; each line
-  is a self-contained `{"type": …}` object.
+## Read First
 
-Subframe types: `Audio`, `CallStart`, `CallEnd`, `StreamInfo`.
-Codecs: `Pcm16Le`, `Pcm16Le8k`, `Opus`, `ImbeRaw`.
+- [`src/lib.rs`](src/lib.rs) for the public re-exports and crate-level format
+  summary.
+- [`src/wire.rs`](src/wire.rs) for binary subframe headers, codecs, frame
+  types, and encode/decode helpers.
+- [`src/jsonl.rs`](src/jsonl.rs) for newline-delimited JSON used by HTTP
+  consumers.
 
-## Why this is a separate crate
+## Protocol Shape
 
-`wavemux` has its own version cadence and dependency set (just
-`serde` + `base64`), so it lives as its own repo + nested submodule
-and is **deliberately excluded from the WaveCatch workspace** (see
-"Hard rules" in `../CLAUDE.md`). Producers and consumers each pin
-it independently.
+Binary mux payloads are a concatenation of subframes. Each subframe starts
+with a 12-byte big-endian header:
 
-## Producers and consumers
+| Offset | Size | Field |
+| --- | --- | --- |
+| 0 | 2 | `substream_id` |
+| 2 | 1 | `subframe_type` |
+| 3 | 1 | `codec` |
+| 4 | 4 | `source_id` |
+| 8 | 4 | `payload_len` |
 
-- **Producer:** `wsrc-server`'s `wavesource_trunked` audio mux
-  endpoints (HTTP + raw TCP).
-- **Consumer:** `wavecap`'s `wcap-ingest::wavemux_jsonl` parser. As
-  of writing, decode of the audio payload is raw-PCM only — Opus
-  and IMBE decoding are tracked in wavecap#1.
+JSONL presents the same subframes as one JSON object per line. Audio payloads
+use base64 in `samples_b64`; control frames carry JSON metadata in `data`.
 
-When you change a wire field here, bump the wavemux submodule
-pointer in WaveCatch and check the wavecap parser.
+## Frame Types
+
+| Type | Purpose |
+| --- | --- |
+| `audio` | PCM, Opus, or raw IMBE audio payload for a substream. |
+| `call_start` | Start metadata for a transmission or trunked call. |
+| `call_end` | End metadata for a transmission or trunked call. |
+| `stream_info` | Substream metadata sent on subscribe or metadata change. |
+| `call_metadata_update` | Mid-call metadata diff, such as encryption state. |
+| `location` | Unit location report metadata. |
+
+## Codecs
+
+| Codec | Meaning |
+| --- | --- |
+| `pcm16le` | Mono i16 little-endian at 48 kHz. |
+| `pcm16le_8k` | Mono i16 little-endian at 8 kHz. |
+| `opus` | Single Opus frame. |
+| `imbe_raw` | Raw 88-bit IMBE voice frame. |
+
+## Validation
+
+Run the crate tests before changing protocol behavior:
+
+```bash
+cargo test
+```
+
+From the parent SDR checkout, the doc-hygiene checks can also validate this
+README:
+
+```bash
+python3 tools/check-md-links.py --repo-root wavemux --all
+python3 tools/check-dir-readmes.py --repo-root wavemux --all
+```


### PR DESCRIPTION
## Summary
- expand the wavemux README into a root landing map
- document the binary header shape, frame types, codecs, and JSONL role
- link the crate modules and sibling SDR repos that produce and consume the protocol

## Validation
- git -C wavemux diff --cached --check
- python3 tools/check-md-links.py --repo-root wavemux --all
- python3 tools/check-dir-readmes.py --repo-root wavemux --all
- cargo test
- scripts/pre-commit