### PR TITLE
docs(wavemux): add canonical repo setup

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -5,6 +5,7 @@ on:
   push:
     branches:
       - main
+      - master
 
 jobs:
   markdown-links:


### PR DESCRIPTION
## Summary
- add the canonical Markdown internal-link checker under scripts/
- add the canonical docs workflow for PRs and main/master pushes
- ensure __pycache__/ is ignored where the repo needed it

## Validation
- python3 scripts/check-md-links.py --all
- parent canonical-repo-setup audit reports ok